### PR TITLE
Add error handling and output.json for proc.sh

### DIFF
--- a/run/annotation/main.py
+++ b/run/annotation/main.py
@@ -388,9 +388,9 @@ def main():
         p2 = time.time()
         makeListTime = p2 - p1
         print('makeListTime :', makeListTime)
-        print('type inputList:', type(inputList[0]), 'len inputList:', len(inputList))
+        # print('type inputList:', type(inputList[0]), 'len inputList:', len(inputList))
         #group or chunks for parallel function
-        groupSize=min((len(inputList) // numCores) + (len(inputList) %numCores), 1000)
+        groupSize=min(max(1, (len(inputList) // numCores) + (len(inputList) %numCores)), 1000)
         print('groupSize:', groupSize)
         groupList=list( getVarGroups(inputList, groupSize) )
         print('type groupList:', type(groupList), 'len:', len(groupList))
@@ -447,8 +447,8 @@ def main():
 
     #write the objects info scores to a file
     print('writing results')
-    df = pd.DataFrame([t.__dict__ for t in varObjList ])
-    print('shape of output file:',df.shape)
+    df = pd.DataFrame([t.__dict__ for t in varObjList], columns=Variant().__dict__.keys())
+    print('shape of output file:', df.shape)
     #write
     fileName=args.outPrefix+'_'+args.patientID+'_scores.txt'
     print('out file name:', fileName)

--- a/run/annotation/marrvel_score_recalc.py
+++ b/run/annotation/marrvel_score_recalc.py
@@ -27,7 +27,7 @@ def load_raw_matrix(score):
                     'hom','hgmd_rs','clin_dict','clin_PLP','clin_PLP_perc','spliceAImax','clin_code','hgmd_id',
                     'hgmd_CLASS','rsId', 'HGVSc', 'HGVSp', 'phenoList', 'phenoInhList']
     
-    return score.loc[:,raw_features].copy()
+    return score[raw_features].copy()
 
 
 

--- a/run/annotation/utils_1.py
+++ b/run/annotation/utils_1.py
@@ -160,6 +160,16 @@ class Variant():
         self.effectOnGeneScore='-'
         self.geneDiseaseAssocScore='-'
         self.modelOrganismScore='-'
+        #additional
+        self.hom='-'
+        self.hgmd_rs='-'
+        self.clin_dict='-'
+        self.clin_PLP='-'
+        self.clin_PLP_perc='-'
+        self.spliceAImax='-'
+        self.clin_code='-'
+        self.hgmd_id='-'
+        self.hgmd_CLASS='-'
 
 
 #function to get var objects from dataframe read from a VEP annoataed file

--- a/run/proc.sh
+++ b/run/proc.sh
@@ -13,26 +13,6 @@ mkdir -m777 /out/scores
 mkdir -m777 /out/final_matrix
 mkdir -m777 /out/final_matrix_expanded
 
-# Function to output JSON to a file
-output_json_to_file() {
-  local status=$1
-  local message=$2
-  echo "{\"status\": \"$status\", \"message\": \"$message\"}" > /out/output.json
-}
-
-exit_with_success() {
-    output_json_to_file "success"
-    exit
-}
-
-exit_with_error() {
-    local message=$1
-    output_json_to_file "error" "$message"
-    exit
-}
-
-trap "exit_with_error INTERNAL_SERVER_ERROR" ERR
-
 REF_DIR=$2
 CHUNK_RAM=$3
 KEEP_INTERMEDIATE=${4:-True}
@@ -158,16 +138,6 @@ mv /out/isec_tmp3/0002.vcf /out/$1.filt.rmBL.vcf
 rm -rf /out/isec_tmp1
 rm -rf /out/isec_tmp2
 rm -rf /out/isec_tmp3
-
-
-#check number of variants left
-variant_count=$(bcftools view -H /out/$1.filt.rmBL.vcf | wc -l)
-if [ "$variant_count" -gt 0 ]; then
-    echo "Blacklist filtering completed successfully. Variants passing the filters: $variant_count"
-else
-    echo "Cannot proceed because all variants were filtered by blacklist."
-    exit_with_error ALL_VARIANTS_WERE_FILTERED__WITH_BLACKLIST ERR
-fi
 
 #annotate with vep
 echo "VEP annotation"
@@ -307,5 +277,3 @@ fi
 mv /out/conf_4Model/*.csv /out/
 mv /out/conf_4Model/integrated/*.csv /out/
 rm -r /out/conf_4Model
-
-exit_with_success


### PR DESCRIPTION
Previously, the proc.sh script did not handle errors and continued running despite encountering issues. This update introduces error handling and generates a machine-readable `output.json` file. This change ensures that errors are properly managed and allows the frontend to respond appropriately based on the JSON output. 

Notably, this update handles the specific case (Issue #19, and possibly #21) where all variants are filtered out by the blacklist.

I know the approach did not get the consensus, so will leave it as a draft PR until we all reach to a consensus.