### PR TITLE
Handle MT values as NaN to avoid string comparison

### DIFF
--- a/run/add_c_nc.py
+++ b/run/add_c_nc.py
@@ -28,6 +28,9 @@ def add_c_nc(score, ref):
     bl = clin_nc.new_start.values
     bc= clin_nc.new_chr.values
 
+    bc[bc=='MT'] = -1 # Treat MT chromosome as NaN values to avoid string comparison
+    bc = bc.astype(int)
+
     i, j = np.where((a[:, None] >= bl) & (a[:, None] <= bh) &(ac[:, None]==bc))
 
     cln=pd.concat([


### PR DESCRIPTION
This is main branch version for one of optimization works done in the nextflow branch.

It reduces the running time of 2.5 minutes for demo.vcf.gz on elpaso server, this running time may differ by your machine.
For more details, please refer the link to https://github.com/hyunhwan-bcm/AI_MARRVEL/pull/1

This change ensures that MT (Mitochondria) values are treated as -1 to mean NaN (Not a Number),
improving the speed by eliminating string comparisons.

