### PR TITLE
Fixed imputation error from a wrong commit

### DIFF
--- a/run/fillna_tier.py
+++ b/run/fillna_tier.py
@@ -127,13 +127,13 @@ def feature_engineering(score_file, tier_file):
     if np.all(pd.isna(patient['GERPpp_RS'])):
         # Single variant query
         patient.loc[(pd.isna(patient['GERPpp_RS'])) & np.array(indel_index), 'GERPpp_RS'] = feature_stat.loc['GERPpp_RS', 'mean']
-        patient.loc[pd.isna(patient['GERPpp_RS']), 'GERPpp_RS'] = feature_stat.loc['GERPpp_RS', 'mean']
+        patient.loc[pd.isna(patient['GERPpp_RS']), 'GERPpp_RS'] = feature_stat.loc['GERPpp_RS', 'min']
         patient['GERPpp_RS'] = patient['GERPpp_RS'].astype('float64')
     else:
         # Patient whole VCF
         patient['GERPpp_RS'] = patient['GERPpp_RS'].astype('float64')
         patient.loc[(pd.isna(patient['GERPpp_RS'])) & np.array(indel_index), 'GERPpp_RS'] = patient['GERPpp_RS'].describe()['mean']
-        patient.loc[pd.isna(patient['GERPpp_RS']), 'GERPpp_RS'] = patient['GERPpp_RS'].describe()['mean']
+        patient.loc[pd.isna(patient['GERPpp_RS']), 'GERPpp_RS'] = patient['GERPpp_RS'].describe()['min']
 
 
     gnomadAFVal = patient['gnomadAF'].copy()
@@ -167,82 +167,82 @@ def feature_engineering(score_file, tier_file):
     if np.all(pd.isna(patient['LRT_score'])):
         # Single variant query
         patient.loc[(pd.isna(patient['LRT_score'])) & np.array(indel_index), 'LRT_score'] = feature_stat.loc['LRT_score', 'mean']
-        patient.loc[pd.isna(patient['LRT_score']), 'LRT_score'] = feature_stat.loc['LRT_score', 'mean']
+        patient.loc[pd.isna(patient['LRT_score']), 'LRT_score'] = feature_stat.loc['LRT_score', 'min']
         patient['LRT_score'] = patient['LRT_score'].astype('float64')
     else:
         # Patient whole VCF
         patient['LRT_score'] = patient['LRT_score'].astype('float64')
         patient.loc[(pd.isna(patient['LRT_score'])) & np.array(indel_index), 'LRT_score'] = patient['LRT_score'].describe()['mean']
-        patient.loc[pd.isna(patient['LRT_score']), 'LRT_score'] = patient['LRT_score'].describe()['mean']
+        patient.loc[pd.isna(patient['LRT_score']), 'LRT_score'] = patient['LRT_score'].describe()['min']
     
     
     patient.loc[patient['LRT_Omega'] == '-', 'LRT_Omega'] = np.NaN
     if np.all(pd.isna(patient['LRT_Omega'])):
         # Single variant query
         patient.loc[(pd.isna(patient['LRT_Omega'])) & np.array(indel_index), 'LRT_Omega'] = feature_stat.loc['LRT_Omega', 'mean']
-        patient.loc[pd.isna(patient['LRT_Omega']), 'LRT_Omega'] = feature_stat.loc['LRT_Omega', 'mean']
+        patient.loc[pd.isna(patient['LRT_Omega']), 'LRT_Omega'] = feature_stat.loc['LRT_Omega', 'min']
         patient['LRT_Omega'] = patient['LRT_Omega'].astype('float64')
     else:
         # Patient whole VCF
         patient['LRT_Omega'] = patient['LRT_Omega'].astype('float64')
         patient.loc[(pd.isna(patient['LRT_Omega'])) & np.array(indel_index), 'LRT_Omega'] = patient['LRT_Omega'].describe()['mean']
-        patient.loc[pd.isna(patient['LRT_Omega']), 'LRT_Omega'] = patient['LRT_Omega'].describe()['mean']
+        patient.loc[pd.isna(patient['LRT_Omega']), 'LRT_Omega'] = patient['LRT_Omega'].describe()['min']
     
     
     patient.loc[patient['phyloP100way_vertebrate'] == '-', 'phyloP100way_vertebrate'] = np.NaN
     if np.all(pd.isna(patient['phyloP100way_vertebrate'])):
         # Single variant query
         patient.loc[(pd.isna(patient['phyloP100way_vertebrate'])) & np.array(indel_index), 'phyloP100way_vertebrate'] = feature_stat.loc['phyloP100way_vertebrate', 'mean']
-        patient.loc[pd.isna(patient['phyloP100way_vertebrate']), 'phyloP100way_vertebrate'] = feature_stat.loc['phyloP100way_vertebrate', 'mean']
+        patient.loc[pd.isna(patient['phyloP100way_vertebrate']), 'phyloP100way_vertebrate'] = feature_stat.loc['phyloP100way_vertebrate', 'min']
         patient['phyloP100way_vertebrate'] = patient['phyloP100way_vertebrate'].astype('float64')
     else:
         # Patient whole VCF
         patient['phyloP100way_vertebrate'] = patient['phyloP100way_vertebrate'].astype('float64')
         patient.loc[(pd.isna(patient['phyloP100way_vertebrate'])) & np.array(indel_index), 'phyloP100way_vertebrate'] = patient['phyloP100way_vertebrate'].describe()['mean']
-        patient.loc[pd.isna(patient['phyloP100way_vertebrate']), 'phyloP100way_vertebrate'] = patient['phyloP100way_vertebrate'].describe()['mean']
+        patient.loc[pd.isna(patient['phyloP100way_vertebrate']), 'phyloP100way_vertebrate'] = patient['phyloP100way_vertebrate'].describe()['min']
 
 
     patient.loc[patient['gnomadGeneZscore'] == '-', 'gnomadGeneZscore'] = np.NaN
     if np.all(pd.isna(patient['gnomadGeneZscore'])):
         # Single variant query
-        patient.loc[pd.isna(patient['gnomadGeneZscore']), 'gnomadGeneZscore'] = feature_stat.loc['gnomadGeneZscore', 'mean']
+        patient.loc[pd.isna(patient['gnomadGeneZscore']), 'gnomadGeneZscore'] = feature_stat.loc['gnomadGeneZscore', 'min']
         patient['gnomadGeneZscore'] = patient['gnomadGeneZscore'].astype('float64')
     else:
         # Patient whole VCF
         patient['gnomadGeneZscore'] = patient['gnomadGeneZscore'].astype('float64')
-        patient.loc[pd.isna(patient['gnomadGeneZscore']), 'gnomadGeneZscore'] = patient['gnomadGeneZscore'].describe()['mean']
+        patient.loc[pd.isna(patient['gnomadGeneZscore']), 'gnomadGeneZscore'] = patient['gnomadGeneZscore'].describe()['min']
 
 
     patient.loc[patient['gnomadGenePLI'] == '-', 'gnomadGenePLI'] = np.NaN
     if np.all(pd.isna(patient['gnomadGenePLI'])):
         # Single variant query
-        patient.loc[pd.isna(patient['gnomadGenePLI']), 'gnomadGenePLI'] = feature_stat.loc['gnomadGenePLI', 'mean']
+        patient.loc[pd.isna(patient['gnomadGenePLI']), 'gnomadGenePLI'] = feature_stat.loc['gnomadGenePLI', 'min']
         patient['gnomadGenePLI'] = patient['gnomadGenePLI'].astype('float64')
     else:
         # Patient whole VCF
         patient['gnomadGenePLI'] = patient['gnomadGenePLI'].astype('float64')
-        patient.loc[pd.isna(patient['gnomadGenePLI']), 'gnomadGenePLI'] = patient['gnomadGenePLI'].describe()['mean']
+        patient.loc[pd.isna(patient['gnomadGenePLI']), 'gnomadGenePLI'] = patient['gnomadGenePLI'].describe()['min']
 
     
     patient.loc[patient['gnomadGeneOELof'] == '-', 'gnomadGeneOELof'] = np.NaN
     if np.all(pd.isna(patient['gnomadGeneOELof'])):
         # Single variant query
-        patient.loc[pd.isna(patient['gnomadGeneOELof']), 'gnomadGeneOELof'] = feature_stat.loc['gnomadGeneOELof', 'mean']
+        patient.loc[pd.isna(patient['gnomadGeneOELof']), 'gnomadGeneOELof'] = feature_stat.loc['gnomadGeneOELof', 'max']
         patient['gnomadGeneOELof'] = patient['gnomadGeneOELof'].astype('float64')
     else:
         # Patient whole VCF
         patient['gnomadGeneOELof'] = patient['gnomadGeneOELof'].astype('float64')
-        patient.loc[pd.isna(patient['gnomadGeneOELof']), 'gnomadGeneOELof'] = patient['gnomadGeneOELof'].describe()['mean']
+        patient.loc[pd.isna(patient['gnomadGeneOELof']), 'gnomadGeneOELof'] = patient['gnomadGeneOELof'].describe()['max']
     
     patient.loc[patient['gnomadGeneOELofUpper'] == '-', 'gnomadGeneOELofUpper'] = np.NaN
     if np.all(pd.isna(patient['gnomadGeneOELofUpper'])):
         # Single variant query
-        patient.loc[pd.isna(patient['gnomadGeneOELofUpper']), 'gnomadGeneOELofUpper'] = feature_stat.loc['gnomadGeneOELofUpper', 'mean']
+        patient.loc[pd.isna(patient['gnomadGeneOELofUpper']), 'gnomadGeneOELofUpper'] = feature_stat.loc['gnomadGeneOELofUpper', 'max']
         patient['gnomadGeneOELofUpper'] = patient['gnomadGeneOELofUpper'].astype('float64')
     else:
         # Patient whole VCF
         patient['gnomadGeneOELofUpper'] = patient['gnomadGeneOELofUpper'].astype('float64')
-        patient.loc[pd.isna(patient['gnomadGeneOELofUpper']), 'gnomadGeneOELofUpper'] = patient['gnomadGeneOELofUpper'].describe()['mean']
+        patient.loc[pd.isna(patient['gnomadGeneOELofUpper']), 'gnomadGeneOELofUpper'] = patient['gnomadGeneOELofUpper'].describe()['max']
 
 
     patient.loc[patient['IMPACT'] == '-','IMPACT'] = 0
@@ -258,26 +258,26 @@ def feature_engineering(score_file, tier_file):
     if np.all(pd.isna(patient['CADD_phred'])):
         # Single variant query
         patient.loc[(pd.isna(patient['CADD_phred'])) & np.array(indel_index), 'CADD_phred'] = feature_stat.loc['CADD_phred', 'mean']
-        patient.loc[pd.isna(patient['CADD_phred']), 'CADD_phred'] = feature_stat.loc['CADD_phred', 'mean']
+        patient.loc[pd.isna(patient['CADD_phred']), 'CADD_phred'] = feature_stat.loc['CADD_phred', 'min']
         patient['CADD_phred'] = patient['CADD_phred'].astype('float64')
     else:
         # Patient whole VCF
         patient['CADD_phred'] = patient['CADD_phred'].astype('float64')
         patient.loc[(pd.isna(patient['CADD_phred'])) & np.array(indel_index), 'CADD_phred'] = patient['CADD_phred'].describe()['mean']
-        patient.loc[pd.isna(patient['CADD_phred']), 'CADD_phred'] = patient['CADD_phred'].describe()['mean']
+        patient.loc[pd.isna(patient['CADD_phred']), 'CADD_phred'] = patient['CADD_phred'].describe()['min']
 
 
     patient.loc[patient['CADD_PHRED'] == '-', 'CADD_PHRED'] = np.NaN
     if np.all(pd.isna(patient['CADD_PHRED'])):
         # Single variant query
         patient.loc[(pd.isna(patient['CADD_PHRED'])) & np.array(indel_index), 'CADD_PHRED'] = feature_stat.loc['CADD_PHRED', 'mean']
-        patient.loc[pd.isna(patient['CADD_PHRED']), 'CADD_PHRED'] = feature_stat.loc['CADD_PHRED', 'mean']
+        patient.loc[pd.isna(patient['CADD_PHRED']), 'CADD_PHRED'] = feature_stat.loc['CADD_PHRED', 'min']
         patient['CADD_PHRED'] = patient['CADD_PHRED'].astype('float64')
     else:
         # Patient whole VCF
         patient['CADD_PHRED'] = patient['CADD_PHRED'].astype('float64')
         patient.loc[(pd.isna(patient['CADD_PHRED'])) & np.array(indel_index), 'CADD_PHRED'] = patient['CADD_PHRED'].describe()['mean']
-        patient.loc[pd.isna(patient['CADD_PHRED']), 'CADD_PHRED'] = patient['CADD_PHRED'].describe()['mean']
+        patient.loc[pd.isna(patient['CADD_PHRED']), 'CADD_PHRED'] = patient['CADD_PHRED'].describe()['min']
 
 
     #DANN_score
@@ -285,13 +285,13 @@ def feature_engineering(score_file, tier_file):
     if np.all(pd.isna(patient['DANN_score'])):
         # Single variant query
         patient.loc[(pd.isna(patient['DANN_score'])) & np.array(indel_index), 'DANN_score'] = feature_stat.loc['DANN_score', 'mean']
-        patient.loc[pd.isna(patient['DANN_score']), 'DANN_score'] = feature_stat.loc['DANN_score', 'mean']
+        patient.loc[pd.isna(patient['DANN_score']), 'DANN_score'] = feature_stat.loc['DANN_score', 'min']
         patient['DANN_score'] = patient['DANN_score'].astype('float64')
     else:
         # Patient whole VCF
         patient['DANN_score'] = patient['DANN_score'].astype('float64')
         patient.loc[(pd.isna(patient['DANN_score'])) & np.array(indel_index), 'DANN_score'] = patient['DANN_score'].describe()['mean']
-        patient.loc[pd.isna(patient['DANN_score']), 'DANN_score'] = patient['DANN_score'].describe()['mean']
+        patient.loc[pd.isna(patient['DANN_score']), 'DANN_score'] = patient['DANN_score'].describe()['min']
 
 
     #REVEL_score
@@ -307,13 +307,13 @@ def feature_engineering(score_file, tier_file):
     if np.all(pd.isna(patient['REVEL_score'])):
         # Single variant query
         patient.loc[(pd.isna(patient['REVEL_score'])) & np.array(indel_index), 'REVEL_score'] = feature_stat.loc['REVEL_score', 'mean']
-        patient.loc[pd.isna(patient['REVEL_score']), 'REVEL_score'] = feature_stat.loc['REVEL_score', 'mean']
+        patient.loc[pd.isna(patient['REVEL_score']), 'REVEL_score'] = feature_stat.loc['REVEL_score', 'min']
         patient['REVEL_score'] = patient['REVEL_score'].astype('float64')
     else:
         # Patient whole VCF
         patient['REVEL_score'] = patient['REVEL_score'].astype('float64')
         patient.loc[(patient['REVEL_score'].isna()) & np.array(indel_index), 'REVEL_score'] = patient['REVEL_score'].describe()['mean']
-        patient.loc[pd.isna(patient['REVEL_score']), 'REVEL_score'] = patient['REVEL_score'].describe()['mean']
+        patient.loc[pd.isna(patient['REVEL_score']), 'REVEL_score'] = patient['REVEL_score'].describe()['min']
 
 
     
@@ -322,13 +322,13 @@ def feature_engineering(score_file, tier_file):
     if np.all(pd.isna(patient['fathmm_MKL_coding_score'])):
         # Single variant query
         patient.loc[(pd.isna(patient['fathmm_MKL_coding_score'])) & np.array(indel_index), 'fathmm_MKL_coding_score'] = feature_stat.loc['fathmm_MKL_coding_score', 'mean']
-        patient.loc[pd.isna(patient['fathmm_MKL_coding_score']), 'fathmm_MKL_coding_score'] = feature_stat.loc['fathmm_MKL_coding_score', 'mean']
+        patient.loc[pd.isna(patient['fathmm_MKL_coding_score']), 'fathmm_MKL_coding_score'] = feature_stat.loc['fathmm_MKL_coding_score', 'min']
         patient['fathmm_MKL_coding_score'] = patient['fathmm_MKL_coding_score'].astype('float64')
     else:
         # Patient whole VCF
         patient['fathmm_MKL_coding_score'] = patient['fathmm_MKL_coding_score'].astype('float64')
         patient.loc[(pd.isna(patient['fathmm_MKL_coding_score'])) & np.array(indel_index), 'fathmm_MKL_coding_score'] = patient['fathmm_MKL_coding_score'].describe()['mean']
-        patient.loc[pd.isna(patient['fathmm_MKL_coding_score']), 'fathmm_MKL_coding_score'] = patient['fathmm_MKL_coding_score'].describe()['mean']
+        patient.loc[pd.isna(patient['fathmm_MKL_coding_score']), 'fathmm_MKL_coding_score'] = patient['fathmm_MKL_coding_score'].describe()['min']
     
 
     #conservationScoreGnomad
@@ -358,13 +358,13 @@ def feature_engineering(score_file, tier_file):
     if np.all(pd.isna(patient['Polyphen2_HDIV_score'])):
         # Single variant query
         patient.loc[(pd.isna(patient['Polyphen2_HDIV_score'])) & np.array(indel_index), 'Polyphen2_HDIV_score'] = feature_stat.loc['Polyphen2_HDIV_score', '50%']
-        patient.loc[pd.isna(patient['Polyphen2_HDIV_score']), 'Polyphen2_HDIV_score'] = feature_stat.loc['Polyphen2_HDIV_score', '50%']
+        patient.loc[pd.isna(patient['Polyphen2_HDIV_score']), 'Polyphen2_HDIV_score'] = feature_stat.loc['Polyphen2_HDIV_score', 'min']
         patient['Polyphen2_HDIV_score'] = patient['Polyphen2_HDIV_score'].astype('float64')
     else:
         # Patient whole VCF
         patient['Polyphen2_HDIV_score'] = patient['Polyphen2_HDIV_score'].astype('float64')
         patient.loc[(pd.isna(patient['Polyphen2_HDIV_score'])) & np.array(indel_index), 'Polyphen2_HDIV_score'] = patient['Polyphen2_HDIV_score'].describe()['50%']
-        patient.loc[pd.isna(patient['Polyphen2_HDIV_score']), 'Polyphen2_HDIV_score'] = patient['Polyphen2_HDIV_score'].describe()['50%']
+        patient.loc[pd.isna(patient['Polyphen2_HDIV_score']), 'Polyphen2_HDIV_score'] = patient['Polyphen2_HDIV_score'].describe()['min']
 
     
     #Polyphen2_HVAR_score
@@ -381,13 +381,13 @@ def feature_engineering(score_file, tier_file):
     if np.all(pd.isna(patient['Polyphen2_HVAR_score'])):
         # Single variant query
         patient.loc[(pd.isna(patient['Polyphen2_HVAR_score'])) & np.array(indel_index), 'Polyphen2_HVAR_score'] = feature_stat.loc['Polyphen2_HVAR_score', '50%']
-        patient.loc[pd.isna(patient['Polyphen2_HVAR_score']), 'Polyphen2_HVAR_score'] = feature_stat.loc['Polyphen2_HVAR_score', '50%']
+        patient.loc[pd.isna(patient['Polyphen2_HVAR_score']), 'Polyphen2_HVAR_score'] = feature_stat.loc['Polyphen2_HVAR_score', 'min']
         patient['Polyphen2_HVAR_score'] = patient['Polyphen2_HVAR_score'].astype('float64')
     else:
         # Patient whole VCF
         patient['Polyphen2_HVAR_score'] = patient['Polyphen2_HVAR_score'].astype('float64')
         patient.loc[(pd.isna(patient['Polyphen2_HVAR_score'])) & np.array(indel_index), 'Polyphen2_HVAR_score'] = patient['Polyphen2_HVAR_score'].describe()['50%']
-        patient.loc[pd.isna(patient['Polyphen2_HVAR_score']), 'Polyphen2_HVAR_score'] = patient['Polyphen2_HVAR_score'].describe()['50%']
+        patient.loc[pd.isna(patient['Polyphen2_HVAR_score']), 'Polyphen2_HVAR_score'] = patient['Polyphen2_HVAR_score'].describe()['min']
 
 
     #SIFT_score
@@ -404,13 +404,13 @@ def feature_engineering(score_file, tier_file):
     if np.all(pd.isna(patient['SIFT_score'])):
         # Single variant query
         patient.loc[(pd.isna(patient['SIFT_score'])) & np.array(indel_index), 'SIFT_score'] = feature_stat.loc['SIFT_score', '50%']
-        patient.loc[pd.isna(patient['SIFT_score']), 'SIFT_score'] = feature_stat.loc['SIFT_score', '50%']
+        patient.loc[pd.isna(patient['SIFT_score']), 'SIFT_score'] = feature_stat.loc['SIFT_score', 'max']
         patient['SIFT_score'] = patient['SIFT_score'].astype('float64')
     else:
         # Patient whole VCF
         patient['SIFT_score'] = patient['SIFT_score'].astype('float64')
         patient.loc[(pd.isna(patient['SIFT_score'])) & np.array(indel_index), 'SIFT_score'] = patient['SIFT_score'].describe()['50%']
-        patient.loc[pd.isna(patient['SIFT_score']), 'SIFT_score'] = patient['SIFT_score'].describe()['50%']
+        patient.loc[pd.isna(patient['SIFT_score']), 'SIFT_score'] = patient['SIFT_score'].describe()['max']
 
 
     patient.loc[patient['zyg'] == 'HET','zyg'] = 1
@@ -440,13 +440,13 @@ def feature_engineering(score_file, tier_file):
     if np.all(pd.isna(patient['FATHMM_score'])):
         # Single variant query
         patient.loc[(pd.isna(patient['FATHMM_score'])) & np.array(indel_index), 'FATHMM_score'] = feature_stat.loc['FATHMM_score', '50%']
-        patient.loc[pd.isna(patient['FATHMM_score']), 'FATHMM_score'] = feature_stat.loc['FATHMM_score', '50%']
+        patient.loc[pd.isna(patient['FATHMM_score']), 'FATHMM_score'] = feature_stat.loc['FATHMM_score', 'max']
         patient['FATHMM_score'] = patient['FATHMM_score'].astype('float64')
     else:
         # Patient whole VCF
         patient['FATHMM_score'] = patient['FATHMM_score'].astype('float64')
         patient.loc[(pd.isna(patient['FATHMM_score'])) & np.array(indel_index), 'FATHMM_score'] = patient['FATHMM_score'].describe()['50%']
-        patient.loc[pd.isna(patient['FATHMM_score']), 'FATHMM_score'] = patient['FATHMM_score'].describe()['50%']
+        patient.loc[pd.isna(patient['FATHMM_score']), 'FATHMM_score'] = patient['FATHMM_score'].describe()['max']
 
 
     #M_CAP_score
@@ -454,13 +454,13 @@ def feature_engineering(score_file, tier_file):
     if np.all(pd.isna(patient['M_CAP_score'])):
         # Single variant query
         patient.loc[(pd.isna(patient['M_CAP_score'])) & np.array(indel_index), 'M_CAP_score'] = feature_stat.loc['M_CAP_score', 'mean']
-        patient.loc[pd.isna(patient['M_CAP_score']), 'M_CAP_score'] = feature_stat.loc['M_CAP_score', 'mean']
+        patient.loc[pd.isna(patient['M_CAP_score']), 'M_CAP_score'] = feature_stat.loc['M_CAP_score', 'min']
         patient['M_CAP_score'] = patient['M_CAP_score'].astype('float64')
     else:
         # Patient whole VCF
         patient['M_CAP_score'] = patient['M_CAP_score'].astype('float64')
         patient.loc[(pd.isna(patient['M_CAP_score'])) & np.array(indel_index), 'M_CAP_score'] = patient['M_CAP_score'].describe()['mean']
-        patient.loc[pd.isna(patient['M_CAP_score']), 'M_CAP_score'] = patient['M_CAP_score'].describe()['mean']
+        patient.loc[pd.isna(patient['M_CAP_score']), 'M_CAP_score'] = patient['M_CAP_score'].describe()['min']
 
 
     #MutationAssessor_score
@@ -477,13 +477,13 @@ def feature_engineering(score_file, tier_file):
     if np.all(pd.isna(patient['MutationAssessor_score'])):
         # Single variant query
         patient.loc[(pd.isna(patient['MutationAssessor_score'])) & np.array(indel_index), 'MutationAssessor_score'] = feature_stat.loc['MutationAssessor_score', '50%']
-        patient.loc[pd.isna(patient['MutationAssessor_score']), 'MutationAssessor_score'] = feature_stat.loc['MutationAssessor_score', '50%']
+        patient.loc[pd.isna(patient['MutationAssessor_score']), 'MutationAssessor_score'] = feature_stat.loc['MutationAssessor_score', 'min']
         patient['MutationAssessor_score'] = patient['MutationAssessor_score'].astype('float64')
     else:
         # Patient whole VCF
         patient['MutationAssessor_score'] = patient['MutationAssessor_score'].astype('float64')
         patient.loc[(pd.isna(patient['MutationAssessor_score'])) & np.array(indel_index), 'MutationAssessor_score'] = patient['MutationAssessor_score'].describe()['50%']
-        patient.loc[pd.isna(patient['MutationAssessor_score']), 'MutationAssessor_score'] = patient['MutationAssessor_score'].describe()['50%']
+        patient.loc[pd.isna(patient['MutationAssessor_score']), 'MutationAssessor_score'] = patient['MutationAssessor_score'].describe()['min']
 
 
     #ESP6500_AA_AF
@@ -491,7 +491,7 @@ def feature_engineering(score_file, tier_file):
     patient['ESP6500_AA_AF'] = patient['ESP6500_AA_AF'].astype('float64')
 
 
-    #ESP6500_AA_AF
+    #ESP6500_EA_AF
     patient.loc[patient['ESP6500_EA_AF'] == '-', 'ESP6500_EA_AF'] = 0.0
     patient['ESP6500_EA_AF'] = patient['ESP6500_EA_AF'].astype('float64')
 
@@ -519,12 +519,12 @@ def feature_engineering(score_file, tier_file):
     patient.loc[patient['spliceAImax'] == '-', 'spliceAImax'] = np.NaN
     if np.all(pd.isna(patient['spliceAImax'])):
         # Single variant query
-        patient.loc[pd.isna(patient['spliceAImax']), 'spliceAImax'] = feature_stat.loc['spliceAImax', 'mean']
+        patient.loc[pd.isna(patient['spliceAImax']), 'spliceAImax'] = feature_stat.loc['spliceAImax', 'min']
         patient['spliceAImax'] = patient['spliceAImax'].astype('float64')
     else:
         # Patient whole VCF
         patient['spliceAImax'] = patient['spliceAImax'].astype('float64')
-        patient.loc[pd.isna(patient['spliceAImax']), 'spliceAImax'] = patient.loc[~pd.isna(patient['spliceAImax']), 'spliceAImax'].describe()['mean']
+        patient.loc[pd.isna(patient['spliceAImax']), 'spliceAImax'] = patient.loc[~pd.isna(patient['spliceAImax']), 'spliceAImax'].describe()['min']
 
 
     #Consequence


### PR DESCRIPTION
In a previous [commit](https://github.com/LiuzLab/AI_MARRVEL/commit/b092559092782baf79ea63a77cea585d43a96de4) of Chaozhong, imputation method has been wrongly replaced with a future dev version.

The imputation method used in our current trained model:
```
Indel: Impute with mean or median
SNP: Impute with least pathogenic value (except for allele frequency)
```

The wrongly committed imputation method:
```
Indel: Impute with mean or median
SNP: Impute with mean or median
```

This PR is to reverse it back so our current model prediction is not affected.    
