### PR TITLE
Add --help flag for displaying usage information to users.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ nextflow run . -params-file params.yaml
 NOTE: You need to create `params.yaml` by copying [params.yaml.example](params.yaml.example) file and follow the instruction.
 
 
-For more information on usage and parameters which can be are open for modification, please use `--help` Option.
+For more information on usage and parameters which are open for modification, please use `--help` option as shown below.
 
 ```
 nextflow run main.nf --help

--- a/README.md
+++ b/README.md
@@ -63,6 +63,14 @@ nextflow run . -params-file params.yaml
 ```
 NOTE: You need to create `params.yaml` by copying [params.yaml.example](params.yaml.example) file and follow the instruction.
 
+
+For more information on usage and parameters which can be are open for modification, please use `--help` Option.
+
+```
+nextflow run main.nf --help
+```
+
+
 ## License
 AI-MARRVEL is licensed under GPL-3.0. You are welcomed to use it for research purpose.  
 For business purpose, please contact us for licensing.

--- a/docs/source/nf_usage.txt
+++ b/docs/source/nf_usage.txt
@@ -1,0 +1,41 @@
+Usage: 
+      
+    nextflow run main.nf [All Args] [Options]
+        
+Example:  
+
+    nextflow run main.nf --ref_dir   path/to/aim_data_dependencies \
+                         --input_vcf path/to/sample.vcf.gz \
+                         --input_hpo path/to/sample/hpos.txt \
+                         --outdir    path/to/sample/Output \ 
+                         --run_id [Sample ID] \
+                         --ref_ver [hg19/hg38] 
+
+Args:
+  --input_vcf               Path to input VCF file.
+  --input_hpo               Path to input HPO file.
+  --ref_dir                 Path to aim pipeline dependencies directory.
+  --outdir                  Output directory.
+  --run_id                  Unique identifier for this run. (default: 1)
+  --ref_ver                 Reference genome version [hg38 or hg19] (default: hg19)
+                  
+
+Options:
+  --exome_filter            Enable exonic filter. Addition will filter out variants outside of exonic region  (default: false)
+  --help                    Displays the usage information.
+
+Reference Files:
+  --ref_loc                 Path to reference location file
+  --ref_to_sym              Path to reference to symbol file
+  --ref_sorted_sym          Path to reference sorted symbol file
+  --ref_exonic_filter_bed   Path to exonic filter BED file
+
+VEP Annotation:
+  --vep_dir_cache           Path to VEP cache directory
+  --vep_dir_plugins         Path to VEP plugins directory
+  --vep_custom_gnomad       Path to custom gnomAD file for VEP
+  --vep_custom_clinvar      Path to custom ClinVar file for VEP
+  --vep_custom_hgmd         Path to custom HGMD file for VEP
+
+For detailed information about each process, 
+please refer to the documentation. https://ai-marrvel.readthedocs.io/en/latest/ 

--- a/main.nf
+++ b/main.nf
@@ -370,8 +370,20 @@ process PREDICTION {
     """
 }
 
+def SHOW_USEAGE() {
+        if (params.help) {
+        def helpFile = file(params.usage_file)  // Specify your Markdown file path here
+        if (helpFile.exists()) {
+            println helpFile.text
+        } else {
+            println "Sorry something went wrong, usage file not found! please vist our website for more info : https://ai-marrvel.readthedocs.io/en/latest/"
+        }
+        exit 0
+    }
+}
 
-workflow { 
+workflow {
+    SHOW_USEAGE()
     INDEX_VCF(params.input_vcf)
     VCF_PRE_PROCESS(INDEX_VCF.out, params.chrmap)
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -66,9 +66,6 @@ params {
     // Documentation
     usage_file = "${projectDir}/docs/source/nf_usage.txt"
 
-    // Documentation
-    usage_file = "${projectDir}/docs/source/nf_usage.txt"
-
     script_chunking = "${projectDir}/scripts/split_chunks.py"
     script_annot = "${projectDir}/scripts/annotation/*.py"
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -1,8 +1,12 @@
 params {
     run_id = 1
+    help = false
     ref_ver = "hg19"
     bed_filter = ""
     exome_filter = false
+    
+    // Will add exceptions in validations.
+    ref_dir = "NOT_PROVIDED"
 
     ref_assembly = params.ref_ver == "hg19" ? "grch37" : "grch38"
 
@@ -58,6 +62,12 @@ params {
     vep_plugin_cadd = "${ref_dir}/vep/${ref_ver}/${vep_cadd_name}" // changed for hg19
     vep_plugin_dbnsfp = "${ref_dir}/vep/${ref_ver}/${vep_dbnsfp_name}"
     vep_idx = "${ref_dir}/vep/${ref_ver}/*.tbi"
+
+    // Documentation
+    usage_file = "${projectDir}/docs/source/nf_usage.txt"
+
+    // Documentation
+    usage_file = "${projectDir}/docs/source/nf_usage.txt"
 
     script_chunking = "${projectDir}/scripts/split_chunks.py"
     script_annot = "${projectDir}/scripts/annotation/*.py"


### PR DESCRIPTION
## Changes: 
- This PR, adds change for introducing new `--help` option for users to get the usage information for AIM next-flow pipeline. 


## TESTING :
- In the `AI_MARRVEL` dir, run the command given below. 
````
nextflow run main.nf --help
````

- expected output : 

````
 N E X T F L O W   ~  version 24.04.2

Launching `main.nf` [loquacious_bohr] DSL2 - revision: 5b9ee9fd9c

Usage: 
      
    nextflow run main.nf [All Args] [Options]
        
Example:  

    nextflow run main.nf --ref_dir   path/to/aim_data_dependencies \
                         --input_vcf path/to/sample.vcf.gz \
                         --input_hpo path/to/sample/hpos.txt \
                         --outdir    path/to/sample/Output \ 
                         --run_id [Sample ID] \
                         --ref_ver [hg19/hg38] 

Args:
  --input_vcf               Path to input VCF file.
  --input_hpo               Path to input HPO file.
  --ref_dir                 Path to aim pipeline dependencies directory.
  --outdir                  Output directory.
  --run_id                  Unique identifier for this run. (default: 1)
  --ref_ver                 Reference genome version [hg38 or hg19] (default: hg19)
                  

Options:
  --exome_filter            Enable exonic filter. Addition will filter out variants outside of exonic region  (default: false)
  --help                    Displays the usage information.

Reference Files:
  --ref_loc                 Path to reference location file
  --ref_to_sym              Path to reference to symbol file
  --ref_sorted_sym          Path to reference sorted symbol file
  --ref_exonic_filter_bed   Path to exonic filter BED file

VEP Annotation:
  --vep_dir_cache           Path to VEP cache directory
  --vep_dir_plugins         Path to VEP plugins directory
  --vep_custom_gnomad       Path to custom gnomAD file for VEP
  --vep_custom_clinvar      Path to custom ClinVar file for VEP
  --vep_custom_hgmd         Path to custom HGMD file for VEP

For detailed information about each process, 
please refer to the documentation. https://ai-marrvel.readthedocs.io/en/latest/ 

````
## QA : 

- Happy Case: Tested cmd `nextflow run main.nf --help` got the expected output.
- Fail Case : Tested  cmd `nextflow run main.nf `, got error and workflow was terminated with output given below as expected.

```
 N E X T F L O W   ~  version 24.04.2

Launching `main.nf` [curious_mercator] DSL2 - revision: 5b9ee9fd9c

WARN: Access to undefined parameter `input_vcf` -- Initialise it to a default value eg. `params.input_vcf = some_value`
ERROR ~ A process input channel evaluates to null -- Invalid declaration `path vcf`

 -- Check script 'main.nf' at line: 387 or see '.nextflow.log' file for more details
 
```



