### PR TITLE
Add validation for required inputs types and display error_messages 

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -4,9 +4,7 @@ params {
     ref_ver = "hg19"
     bed_filter = ""
     exome_filter = false
-    
-    // Will add exceptions in validations.
-    ref_dir = "NOT_PROVIDED"
+
 
     ref_assembly = params.ref_ver == "hg19" ? "grch37" : "grch38"
 


### PR DESCRIPTION
## Changes :
- This PR is to add validation for required inputs for missing entries and wrong file type.
- In favor of [Issue-#49](https://github.com/LiuzLab/AI_MARRVEL/issues/49)

## Testing :

- Happy Case : All inputs are provided.

```
output: 
 N E X T F L O W   ~  version 24.04.2

Launching `./main.nf` [lethal_ptolemy] DSL2 - revision: 1e18d4b88b
executor >  local (15)
[skipped  ] process > BUILD_REFERENCE_INDEX      [100%] 1 of 1, stored: 1 ✔
[5a/d40650] process > INDEX_VCF                  [100%] 1 of 1 ✔
[85/740ee0] process > VCF_PRE_PROCESS_PART1      [100%] 1 of 1 ✔
[fa/a621cb] process > VCF_PRE_PROCESS_PART2      [100%] 1 of 1 ✔
[7d/6af2f5] process > ANNOT_PHRANK               [100%] 1 of 1 ✔
[c4/e3440c] process > ANNOT_ENSMBLE              [100%] 1 of 1 ✔
[2f/22a7ee] process > TO_GENE_SYM                [100%] 1 of 1 ✔
[a2/999273] process > PHRANK_SCORING             [100%] 1 of 1 ✔
[96/43a78f] process > HPO_SIM                    [100%] 1 of 1 ✔
[c7/2a9923] process > REMOVE_MITO_AND_UNKOWN_CHR [100%] 1 of 1 ✔
[3c/658a8c] process > FILTER_BED                 [100%] 1 of 1 ✔
[cf/d007e8] process > FILTER_PROBAND             [100%] 1 of 1 ✔
[57/d09add] process > VEP_ANNOTATE               [100%] 1 of 1 ✔
[5f/e3fd9d] process > FEATURE_ENGINEERING_PART1  [100%] 1 of 1 ✔
[3e/de0210] process > FEATURE_ENGINEERING_PART2  [100%] 1 of 1 ✔
[dc/9cee66] process > PREDICTION                 [100%] 1 of 1 ✔
Completed at: 16-Aug-2024 21:02:07
Duration    : 21m 39s
CPU hours   : 5.8
Succeeded   : 15
```
- Missing fields: In case of params are not provided, 

```

WARN: Access to undefined parameter `input_vcf` -- Initialise it to a default value eg. `params.input_vcf = some_value`
WARN: Access to undefined parameter `input_hpo` -- Initialise it to a default value eg. `params.input_hpo = some_value`
Input parameter 'input_vcf' not specified or is null!

  To see usage and available parameters run `nextflow run main.nf --help`
````

- Wrong file Type : In case the params file provided doesn't fix the required file extension

````
Launching `./main.nf` [marvelous_swartz] DSL2 - revision: 83978dd9e8

Error: '--input_vcf' value '/home/sample/' should be a VCF file (.vcf) or (.vcf.gz)
  
  To see usage and available parameters run `nextflow run main.nf --help`

````
`````
Launching `./main.nf` [naughty_boltzmann] DSL2 - revision: 83978dd9e8

Error: '--input_hpo' value '/home/sample/sample.vcf.gz' should be an HPO file (.hpo) or (.txt)

  To see usage and available parameters run `nextflow run main.nf --help`
  
`````

- When `ref_dir` is not a directory,
````

Launching `./main.nf` [loving_kay] DSL2 - revision: 5369268806

Error: '--ref_dir' value 'sample_vcf_for_n/smaple.vcf.gz' should be an directory.

  To see usage and available parameters run `nextflow run main.nf --help`

````

- Mismatch string for `ref_ver`

`````
Launching `./main.nf` [pensive_cajal] DSL2 - revision: 9fa2503416

Error: '--ref_ver' value 'hg1' should be either set to 'hg19' or 'hg38'.

  To see usage and available parameters run `nextflow run main.nf --help`
  
`````



