### PR TITLE
Rename and Regroup Processes More Meaningfully

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -66,7 +66,7 @@ validateInputParams()
 
 
 // Process to handle the VCF file
-process INDEX_VCF {
+process NORMALIZE_VCF {
     input:
     path vcf
 
@@ -146,7 +146,7 @@ process BUILD_REFERENCE_INDEX {
     """
 }
 
-process VCF_PRE_PROCESS_PART1 {
+process FILTER_GVCF {
     container "broadinstitute/gatk"
 
     input:
@@ -213,7 +213,7 @@ process VCF_PRE_PROCESS_PART1 {
 }
 
 
-process VCF_PRE_PROCESS_PART2 {
+process FILTER_QUALITY {
     input:
     path vcf
     path tbi
@@ -248,7 +248,7 @@ process VCF_PRE_PROCESS_PART2 {
 }
 
 
-process REMOVE_MITO_AND_UNKOWN_CHR {
+process FILTER_MITO_AND_UNKOWN_CHR {
     publishDir "${params.outdir}/vcf/", mode: 'copy'
     input:
     path vcf
@@ -269,7 +269,7 @@ process REMOVE_MITO_AND_UNKOWN_CHR {
 }
 
 
-process ANNOT_PHRANK {
+process VCF_TO_VAR {
     input:
     path vcf
 
@@ -284,7 +284,7 @@ process ANNOT_PHRANK {
 }
 
 
-process ANNOT_ENSMBLE {
+process VAR_TO_ENSEMBL {
     input:
     path var
     path ref
@@ -301,7 +301,7 @@ process ANNOT_ENSMBLE {
 }
 
 
-process TO_GENE_SYM {
+process ENSEMBL_TO_GENESYM {
     input:
     path ensmbl
     path ref_to_sym
@@ -318,7 +318,7 @@ process TO_GENE_SYM {
 }
 
 
-process PHRANK_SCORING {
+process GENESYM_TO_PHRANK {
     publishDir "${params.outdir}/phrank/", mode: 'copy'
 
     input:
@@ -372,7 +372,7 @@ process FILTER_PROBAND {
     path ref_gnomad_exome_idx
 
     output:
-    path "${params.run_id}.filt.rmBL.vcf"
+    path "${params.run_id}.filt.rmBL.vcf", emit: vcf
 
     script:
     """
@@ -418,6 +418,7 @@ process SPLIT_VCF_BY_CHROMOSOME {
 }
 
 process VEP_ANNOTATE {
+    tag "${vcf.simpleName}"
     publishDir "${params.outdir}/vep/", mode: "copy"
 
     input:
@@ -458,11 +459,13 @@ process VEP_ANNOTATE {
     """
 }
 
-process FEATURE_ENGINEERING_PART1 {
+process DB_ANNOTATE {
+    tag "${vep.simpleName}"
+
     input:
     path vep
-    path hgmd_sim
-    path omim_sim
+    path hgmd_sim, stageAs: "hgmd_sim.tsv"
+    path omim_sim, stageAs: "omim_sim.tsv"
     path ref_annot_dir
 
     output:
@@ -484,9 +487,11 @@ process FEATURE_ENGINEERING_PART1 {
     """
 }
 
-process FEATURE_ENGINEERING_PART2 {
+process JOIN_TIER_PHRANK_PART1 {
+    tag "${scores.simpleName}"
+
     input:
-    path scores, stageAs: "scores.csv"
+    path scores
     path phrank
 
     path ref_annot_dir
@@ -494,19 +499,20 @@ process FEATURE_ENGINEERING_PART2 {
     path ref_merge_expand_dir
 
     output:
-    path "${scores.baseName}_scores.txt.gz", emit: compressed_scores
-    path "${scores.baseName}_Tier.v2.tsv", emit: tier
+    path "${scores.simpleName}_scores.txt.gz", emit: compressed_scores
+    path "${scores.simpleName}_Tier.v2.tsv", emit: tier
 
     script:
     """
+    mv $scores scores.csv
     VarTierDiseaseDBFalse.R ${params.ref_ver}
     generate_new_matrix_2.py ${params.run_id} ${params.ref_ver}
-    mv scores.txt.gz  ${scores.baseName}_scores.txt.gz
-    mv Tier.v2.tsv ${scores.baseName}_Tier.v2.tsv
+    mv scores.txt.gz  ${scores.simpleName}_scores.txt.gz
+    mv Tier.v2.tsv ${scores.simpleName}_Tier.v2.tsv
     """
 }
 
-process MERGE_RESULTS {
+process JOIN_TIER_PHRANK_PART2 {
     publishDir "${params.outdir}/merged", mode: "copy"
 
     input:
@@ -570,47 +576,35 @@ process PREDICTION {
     """
 }
 
-workflow {
-    BUILD_REFERENCE_INDEX()
+workflow VCF_PRE_PROCESS {
+    take:
+    vcf
+    tbi
+    fasta
+    fasta_index
+    fasta_dict
 
-    INDEX_VCF(params.input_vcf)
-    VCF_PRE_PROCESS_PART1(
-        INDEX_VCF.out.vcf,
-        INDEX_VCF.out.tbi,
-        BUILD_REFERENCE_INDEX.out.fasta,
-        BUILD_REFERENCE_INDEX.out.fasta_index,
-        BUILD_REFERENCE_INDEX.out.fasta_dict,
+    main:
+    FILTER_GVCF(
+        vcf,
+        tbi,
+        fasta,
+        fasta_index,
+        fasta_dict,
         params.chrmap
     )
-    VCF_PRE_PROCESS_PART2(
-        VCF_PRE_PROCESS_PART1.out.vcf,
-        VCF_PRE_PROCESS_PART1.out.tbi,
+    FILTER_QUALITY(
+        FILTER_GVCF.out.vcf,
+        FILTER_GVCF.out.tbi,
         params.chrmap
     )
-
-    ANNOT_PHRANK(INDEX_VCF.out.vcf)
-    ANNOT_ENSMBLE(ANNOT_PHRANK.out, params.ref_loc)
-    TO_GENE_SYM(ANNOT_ENSMBLE.out, params.ref_to_sym, params.ref_sorted_sym)
-    PHRANK_SCORING(TO_GENE_SYM.out,
-                    params.input_hpo,
-                    params.phrank_dagfile,
-                    params.phrank_disease_annotation,
-                    params.phrank_gene_annotation,
-                    params.phrank_disease_gene)
-
-    HPO_SIM(params.input_hpo,
-            params.omim_hgmd_phen,
-            params.omim_obo,
-            params.omim_genemap2,
-            params.omim_pheno)
-
-    REMOVE_MITO_AND_UNKOWN_CHR(
-        VCF_PRE_PROCESS_PART2.out.vcf,
-        VCF_PRE_PROCESS_PART2.out.tbi,
+    FILTER_MITO_AND_UNKOWN_CHR(
+        FILTER_QUALITY.out.vcf,
+        FILTER_QUALITY.out.tbi,
     )
     FILTER_BED(
-        REMOVE_MITO_AND_UNKOWN_CHR.out.vcf,
-        REMOVE_MITO_AND_UNKOWN_CHR.out.tbi,
+        FILTER_MITO_AND_UNKOWN_CHR.out.vcf,
+        FILTER_MITO_AND_UNKOWN_CHR.out.tbi,
         moduleDir.resolve(params.ref_filter_bed),
     )
     FILTER_PROBAND(
@@ -621,7 +615,43 @@ workflow {
         params.ref_gnomad_exome,
         params.ref_gnomad_exome_idx
     )
-    SPLIT_VCF_BY_CHROMOSOME(FILTER_PROBAND.out)
+
+    emit:
+    vcf = FILTER_PROBAND.out.vcf
+}
+
+workflow PHRANK_SCORING {
+    take:
+    vcf
+
+    main:
+    VCF_TO_VAR(vcf)
+    VAR_TO_ENSEMBL(VCF_TO_VAR.out, params.ref_loc)
+    ENSEMBL_TO_GENESYM(VAR_TO_ENSEMBL.out, params.ref_to_sym, params.ref_sorted_sym)
+    GENESYM_TO_PHRANK(ENSEMBL_TO_GENESYM.out,
+                    params.input_hpo,
+                    params.phrank_dagfile,
+                    params.phrank_disease_annotation,
+                    params.phrank_gene_annotation,
+                    params.phrank_disease_gene)
+
+    emit:
+    phrank = GENESYM_TO_PHRANK.out
+}
+
+workflow {
+    NORMALIZE_VCF(params.input_vcf)
+    BUILD_REFERENCE_INDEX()
+
+    VCF_PRE_PROCESS(
+        NORMALIZE_VCF.out.vcf,
+        NORMALIZE_VCF.out.tbi,
+        BUILD_REFERENCE_INDEX.out.fasta,
+        BUILD_REFERENCE_INDEX.out.fasta_index,
+        BUILD_REFERENCE_INDEX.out.fasta_dict,
+    )
+
+    SPLIT_VCF_BY_CHROMOSOME(VCF_PRE_PROCESS.out.vcf)
     VEP_ANNOTATE(
         SPLIT_VCF_BY_CHROMOSOME.out.chr_vcfs.flatten(),
         params.vep_dir_cache,
@@ -637,15 +667,25 @@ workflow {
         file(params.vep_idx)
     )
 
-    FEATURE_ENGINEERING_PART1 ( // will rename it once we have analyzed/review the part
+    HPO_SIM(params.input_hpo,
+            params.omim_hgmd_phen,
+            params.omim_obo,
+            params.omim_genemap2,
+            params.omim_pheno)
+
+    DB_ANNOTATE ( // will rename it once we have analyzed/review the part
         VEP_ANNOTATE.out.vep_output,
         HPO_SIM.out.hgmd_sim,
         HPO_SIM.out.omim_sim,
         file(params.ref_annot_dir)
     )
 
-    FEATURE_ENGINEERING_PART2 (
-        FEATURE_ENGINEERING_PART1.out.scores,
+    PHRANK_SCORING(
+        NORMALIZE_VCF.out.vcf,
+    )
+
+    JOIN_TIER_PHRANK_PART1 (
+        DB_ANNOTATE.out.scores,
         PHRANK_SCORING.out,
 
         file(params.ref_annot_dir),
@@ -653,19 +693,19 @@ workflow {
         file(params.ref_merge_expand_dir)
     )
 
-    MERGE_RESULTS(
+    JOIN_TIER_PHRANK_PART2(
         PHRANK_SCORING.out,
-        FEATURE_ENGINEERING_PART2.out.tier.collect(),
-        FEATURE_ENGINEERING_PART2.out.compressed_scores.collect(),
+        JOIN_TIER_PHRANK_PART1.out.tier.collect(),
+        JOIN_TIER_PHRANK_PART1.out.compressed_scores.collect(),
         file(params.ref_annot_dir),
         file(params.ref_mod5_diffusion_dir),
         file(params.ref_merge_expand_dir)
     )
 
     // Run Prediction on the final merged output
-    PREDICTION( 
-        MERGE_RESULTS.out.merged_matrix,
-        MERGE_RESULTS.out.merged_compressed_scores,
+    PREDICTION(
+        JOIN_TIER_PHRANK_PART2.out.merged_matrix,
+        JOIN_TIER_PHRANK_PART2.out.merged_compressed_scores,
         file(params.ref_predict_new_dir),
         file(params.ref_model_inputs_dir)
     )


### PR DESCRIPTION
# Changes
* Grouped related processes with a named workflow
* Used tags for processes for chromosome-split tasks
* Renamed with more descriptive and meaningful names

Feedback is welcome!
(8/21/2024 Updated)
```bash
[56/255d05] NORMALIZE_VCF                              | 1 of 1 ✔
[skipped  ] BUILD_REFERENCE_INDEX                      | 1 of 1, stored: 1 ✔
[8e/f1bb72] VCF_PRE_PROCESS:CONVERT_GVCF               | 1 of 1 ✔
[a9/a21546] VCF_PRE_PROCESS:FILTER_UNPASSED            | 1 of 1 ✔
[22/b8d42f] VCF_PRE_PROCESS:FILTER_MITO_AND_UNKOWN_CHR | 1 of 1 ✔
[55/61ce9e] VCF_PRE_PROCESS:FILTER_BED                 | 1 of 1 ✔
[73/7801a9] VCF_PRE_PROCESS:FILTER_PROBAND             | 1 of 1 ✔
[b5/e5e11b] SPLIT_VCF_BY_CHROMOSOME                    | 1 of 1 ✔
[e8/4685df] ANNOTATE_BY_VEP (chr2)                     | 24 of 24 ✔
[2a/ba562a] HPO_SIM                                    | 1 of 1 ✔
[e7/a0d1dd] ANNOTATE_BY_MODULES (chr2)                 | 24 of 24 ✔
[f2/fa2555] PHRANK_SCORING:VCF_TO_VARIANTS             | 1 of 1 ✔
[e4/041f19] PHRANK_SCORING:VARIANTS_TO_ENSEMBL         | 1 of 1 ✔
[48/488ced] PHRANK_SCORING:ENSEMBL_TO_GENESYM          | 1 of 1 ✔
[a8/e8cc67] PHRANK_SCORING:GENESYM_TO_PHRANK           | 1 of 1 ✔
[09/24236b] JOIN_TIER_PHRANK (chr2)                    | 24 of 24 ✔
[9d/4682bb] MERGE_SCORES_BY_CHROMOSOME                 | 1 of 1 ✔
[89/b0f278] PREDICTION                                 | 1 of 1 ✔
```