### PR TITLE
fix empty HPO error.

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -354,7 +354,7 @@ process HPO_SIM {
 
     script:
     """
-    if [ ! -s $hpo ]; then
+    if [[ -z \$(egrep 'HP:[0-9]{7}' $hpo) ]] ; then
         echo "HP:0000001" > $hpo
     fi
 

--- a/main.nf
+++ b/main.nf
@@ -354,6 +354,10 @@ process HPO_SIM {
 
     script:
     """
+    if [ ! -s $hpo ]; then
+        echo "HP:0000001" > $hpo
+    fi
+
     phenoSim.R $hpo $omim_hgmd_phen $omim_obo $omim_genemap2 $omim_pheno \\
         ${params.run_id}-cz ${params.run_id}-dx
     """


### PR DESCRIPTION
The HPO correction in `main` hadn't applied to `nextflow_conversion`.

https://github.com/LiuzLab/AI_MARRVEL/blob/47df5f61d4e11e70244715aad5918d7dfa851798/run/proc.sh#L28

Now the code for handling the empty/invalid HPO has been added in `HPO_SIM`, and here is the output from the workdir:

```
❯ cd ef/e2e89a3bc359568cbd931485ff0096
❯ ls
 70M 22 Aug 15:16  1-cz
2.8M 22 Aug 15:16  1-dx
   - 22 Aug 15:15  demo_empty_HPO.txt -> /Users/hyun-hwanjeong/Downloads/demo_empty_HPO.txt
   - 22 Aug 15:15  genemap2_v2022.rds -> /Volumes/HWAN-T7/data-dependency/omim_annotate/hg19/genemap2_v2022.rds
   - 22 Aug 15:15  HGMD_phen.tsv -> /Volumes/HWAN-T7/data-dependency/omim_annotate/hg19/HGMD_phen.tsv
   - 22 Aug 15:15  hp.obo -> /Volumes/HWAN-T7/data-dependency/omim_annotate/hp.obo
   - 22 Aug 15:15  HPO_OMIM.tsv -> /Volumes/HWAN-T7/data-dependency/omim_annotate/hg19/HPO_OMIM.tsv
❯ cat demo_empty_HPO.txt
HP:0000001
```


