### PR TITLE
Fix an issue with `--help`

### DIFF
--- a/docs/source/nf_usage.txt
+++ b/docs/source/nf_usage.txt
@@ -18,6 +18,7 @@ Args:
   --outdir                  Output directory.
   --run_id                  Unique identifier for this run. (default: 1)
   --ref_ver                 Reference genome version [hg38 or hg19] (default: hg19)
+  --bed_filter              Path to a BED file to perform an analysis only for regions of interest (optional)
                   
 
 Options:

--- a/nextflow.config
+++ b/nextflow.config
@@ -2,7 +2,8 @@ params {
     run_id = 1
     help = false
     ref_ver = "hg19"
-    bed_filter = ""
+    bed_filter = " "
+    ref_dir = " "
     exome_filter = false
 
 


### PR DESCRIPTION
`nextflow run . --help` generated an error like this 

```
ERROR ~ Unknown config attribute `params.ref_dir` -- check config file: /Users/hyun-hwanjeong/Workspaces/AI_MARRVEL/nextflow.config

 -- Check '.nextflow.log' file for details
```

This was due to empty string/null variables being considered undeclared, so I put `" "` (string with single whitespace) to avoid the error.

