### PR TITLE
Organize the use of out_dir

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -128,7 +128,7 @@ process FILTER_BED {
 
 process BUILD_REFERENCE_INDEX {
     container "broadinstitute/gatk"
-    storeDir projectDir.resolve("out/reference_index/")
+    storeDir "${params.outdir}/general/reference_index/"
 
     output:
     path "final_${params.ref_ver}.fa", emit: fasta
@@ -249,7 +249,7 @@ process FILTER_UNPASSED {
 
 
 process FILTER_MITO_AND_UNKOWN_CHR {
-    publishDir "${params.outdir}/vcf/", mode: 'copy'
+    publishDir "${params.outdir}/${params.run_id}/vcf/", mode: 'copy'
     input:
     path vcf
     path tbi
@@ -319,7 +319,7 @@ process ENSEMBL_TO_GENESYM {
 
 
 process GENESYM_TO_PHRANK {
-    publishDir "${params.outdir}/phrank/", mode: 'copy'
+    publishDir "${params.outdir}/${params.run_id}/phrank/", mode: 'copy'
 
     input:
     path gene
@@ -365,7 +365,7 @@ process HPO_SIM {
 }
 
 process FILTER_PROBAND {
-    publishDir "${params.outdir}/vcf/", mode: 'copy'
+    publishDir "${params.outdir}/${params.run_id}/vcf/", mode: 'copy'
 
     input:
     path vcf
@@ -423,7 +423,7 @@ process SPLIT_VCF_BY_CHROMOSOME {
 
 process ANNOTATE_BY_VEP {
     tag "${vcf.simpleName}"
-    publishDir "${params.outdir}/vep/", mode: "copy"
+    publishDir "${params.outdir}/${params.run_id}/vep/", mode: "copy"
 
     input:
     path vcf
@@ -517,7 +517,7 @@ process JOIN_TIER_PHRANK {
 }
 
 process MERGE_SCORES_BY_CHROMOSOME {
-    publishDir "${params.outdir}/merged", mode: "copy"
+    publishDir "${params.outdir}/${params.run_id}/merged", mode: "copy"
 
     input:
     path phrank
@@ -556,7 +556,7 @@ process MERGE_SCORES_BY_CHROMOSOME {
 }
 
 process PREDICTION {
-    publishDir "${params.outdir}/prediction/", mode: "copy"
+    publishDir "${params.outdir}/${params.run_id}/prediction/", mode: "copy"
 
     input:
     path merged_matrix  


### PR DESCRIPTION
# Motivation

We recently started using the Nextflow `storeDir` directive, which allows us to cache certain outputs that are independent of the user's input. This enables some output files to be shared across multiple runs, avoiding unnecessary regeneration.

Currently, if we use the same output directory for multiple runs, the content gets overwritten, preventing shared outputs from being reused effectively. To address this, this change introduces a separate subdirectory for each run, identified by a `run_id`, within the output directory. This allows us to store shared outputs that are generated only once and reused across multiple runs, without risk of overwriting. This PR resolves the Issue #77 

# Previous Directory Structure

```
out/
├── merged
├── phrank
├── prediction
├── reference_index
└── vep
```
In this structure, all runs share the same output directory, regardless of the run_id.

# New Directory Structure
```
out/
├── 1
│   ├── merged
│   ├── phrank
│   ├── prediction
│   ├── vcf
│   └── vep
└── general
    └── reference_index
```


With this change, outputs are organized by run_id, while the shared outputs are stored separately in the general directory.

# Impact
This change introduces a breaking change for downstream workflows, such as those involving the web interface. I would appreciate your feedback on this approach!

@hyunhwan-bcm @ZaahidShaik @arine

