### PR TITLE
Minimize the metadata of VCF at the beginning of the workflow

### DIFF
--- a/bin/minimize_vcf.py
+++ b/bin/minimize_vcf.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3.8
+
+import pandas as pd
+import sys
+import io
+
+def main():
+    inputvcf = sys.stdin.read()
+    df = pd.read_csv(io.StringIO(inputvcf), sep="\t", comment="#", header=None)
+    df = df.rename(columns={
+        0: '#CHROM',
+        1: 'POS',
+        2: 'ID',
+        3: 'REF',
+        4: 'ALT',
+        5: 'QUAL',
+        6: 'FILTER',
+        7: 'INFO',
+        8: 'FORMAT',
+    })
+    df[["INFO"]] = "."
+    df = df[df.FILTER == "PASS"]
+    vcfbody = df.to_csv(sep="\t", index=False)
+
+    vcfformatheader = "\n".join(line for line in inputvcf.splitlines() if line.startswith("##FORMAT"))
+    vcfcontigheader = "\n".join(f"##contig=<ID={chr},length={gdf.POS.max()}>" for (chr, gdf) in df.groupby("#CHROM"))
+
+    vcfheader = f"""
+##fileformat=VCFv4.2
+{vcfformatheader}
+{vcfcontigheader}
+    """.strip()
+
+    vcfcontent = f"""
+{vcfheader}
+{vcfbody}
+    """.strip()
+
+    print(vcfcontent)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
To avoid the situation that the workflow fails to handle vcf files in a wrong format, especially with the header information, which are mostly not used for our workflow at all. 

Specifically, our workflow extensively uses both software of `bcftools` and `tabix`, but when the header information is in wrong format, most of commands either of `bcftools` or `tabix` used to fail.

I would like to ask your review about:
* @hyunhwan-bcm, please review if the new logic is placed properly, or suggest the other places for me.
* @arine, please suggest me if this code needs more test cases: currently I have tested with demo data and the most recently reported data.
