### PR TITLE
Update Scikit Learn to >=1.3.0 and Stop Using predict_new/

### DIFF
--- a/bin/run_final.py
+++ b/bin/run_final.py
@@ -10,10 +10,10 @@ from predict_new.confidence import *
 import sys
 
 # read in precalulated model
-model = joblib.load("predict_new/hg19/final_model_wo_bg_val.job")
+model = joblib.load("model_inputs/default/final_model.job")
 
 # read in features to use
-features = list(pd.read_csv("predict_new/hg19/features.csv"))
+features = list(pd.read_csv("model_inputs/default/features.csv"))
 
 # predict with Linhua's code
 out = rank_patient(model, sys.argv[1] + ".matrix.txt", features, train_causals=None)

--- a/main.nf
+++ b/main.nf
@@ -572,7 +572,6 @@ process PREDICTION {
     path merged_matrix  
     path merged_compressed_scores  
 
-    path ref_predict_new_dir
     path ref_model_inputs_dir
 
     output:
@@ -720,7 +719,6 @@ workflow {
     PREDICTION(
         MERGE_SCORES_BY_CHROMOSOME.out.merged_matrix,
         MERGE_SCORES_BY_CHROMOSOME.out.merged_compressed_scores,
-        file(params.ref_predict_new_dir),
         file(params.ref_model_inputs_dir)
     )
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ tqdm
 matplotlib
 requests
 tables
-scikit-learn==1.1.2
+scikit-learn>=1.3.0


### PR DESCRIPTION
This PR is required in order to replace the model with recently retrained one, with higher accuracy.

Since this PR updated `requirements.txt`, we need to rebuild `Dockerfile` and Update the dockerhub image as well.