### PR TITLE
Validate VCF First Before Preprocessing

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -74,6 +74,19 @@ showUsage()
 showVersion()
 validateInputParams()
 
+process VALIDATE_VCF {
+    container 'quay.io/biocontainers/vcftools:0.1.16--pl5321hdcf5f25_11'
+
+    input:
+    path vcf
+
+    output:
+    path "$vcf", emit: vcf
+
+    """
+    vcf-validator $vcf
+    """
+}
 
 // Process to handle the VCF file
 process NORMALIZE_VCF {
@@ -654,7 +667,8 @@ workflow PHRANK_SCORING {
 }
 
 workflow {
-    NORMALIZE_VCF(params.input_vcf)
+    VALIDATE_VCF(params.input_vcf)
+    NORMALIZE_VCF(VALIDATE_VCF.out.vcf)
     BUILD_REFERENCE_INDEX()
 
     VCF_PRE_PROCESS(


### PR DESCRIPTION
**Validation Fail Example**
```bash
Execution cancelled -- Finishing pending tasks before exit
ERROR ~ Error executing process > 'VALIDATE_VCF'

Caused by:
  Process `VALIDATE_VCF` terminated with an error exit status (25)


Command executed:

  vcf-validator 241120.vcf

Command exit status:
  25
                                                                                                                                                                                                                           ─────────
Command output:
  (empty)

Command error:
  The column names not tab-separated? [#CHROM  POS     ID      REF     ALT     QUAL    FILTER  INFO    FORMAT  Example]
  Could not parse the line, wrong number of columns: [chr11   65345691        .       A       AC      104.73  .       AC=1;AF=0.5;AN=2;BaseQRankSum=0.315;ClippingRankSum=-0.000;DP=12;ExcessHet=3.0103;FS=5.332;MLEAC=1;MLEAF=0.5;MQ=60.00;MQRankSum=-0.000;QD=8.73;ReadPosRankSum=-0.869;SOR=1.930       GT:AD:DP:GQ:PL  0/1:7,5:12:99:142,0,214\n]
   at /usr/local/lib/perl5/site_perl/Vcf.pm line 172, <__ANONIO__> line 50.
        Vcf::throw(Vcf4_2=HASH(0x55af39a34528), "Could not parse the line, wrong number of columns: [chr11   6"...) called at /usr/local/lib/perl5/site_perl/Vcf.pm line 335
        Vcf::next_data_array(Vcf4_2=HASH(0x55af39a34528)) called at /usr/local/lib/perl5/site_perl/Vcf.pm line 3498
        Vcf4_1::next_data_array(Vcf4_2=HASH(0x55af39a34528)) called at /usr/local/lib/perl5/site_perl/Vcf.pm line 2575
        VcfReader::run_validation(Vcf4_2=HASH(0x55af39a34528)) called at /usr/local/bin/vcf-validator line 60
        main::do_validation(HASH(0x55af39a004d8)) called at /usr/local/bin/vcf-validator line 14

```